### PR TITLE
WIP: implement `upgrade_all_documents`

### DIFF
--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -1,14 +1,28 @@
 import filecmp
 from pathlib import Path
 
-from cwlupgrader.main import load_cwl_document, main, upgrade_document
+from cwlupgrader.main import load_cwl_document, upgrade_all_documents, upgrade_document
 
 from .util import get_data
 
 
-def test_draft3_workflow(tmp_path: Path) -> None:
-    """Basic draft3 to CWL v1.1 test."""
-    main([f"--dir={tmp_path}", "--v1-only", get_data("testdata/draft-3/wf.cwl")])
+# def test_draft3_workflow(tmp_path: Path) -> None:
+#     """Basic draft3 to CWL v1.1 test."""
+#     main([f"--dir={tmp_path}", "--v1-only", get_data("testdata/draft-3/wf.cwl")])
+#     result = filecmp.cmp(
+#         get_data("testdata/v1.0/wf.cwl"),
+#         tmp_path / "wf.cwl",
+#         shallow=False,
+#     )
+#     assert result
+
+def test_upgrade_all_documents(tmp_path: Path) -> None:
+    """Test `upgrade_all_documents`"""
+    upgrade_all_documents(
+        base_dir=get_data("testdata/draft-3"),
+        output_dir=tmp_path,
+        target_version="v1.0",
+        overwrite=True)
     result = filecmp.cmp(
         get_data("testdata/v1.0/wf.cwl"),
         tmp_path / "wf.cwl",
@@ -17,22 +31,22 @@ def test_draft3_workflow(tmp_path: Path) -> None:
     assert result
 
 
-def test_invalid_target(tmp_path: Path) -> None:
+def test_invalid_target() -> None:
     """Test for invalid target version"""
     doc = load_cwl_document(get_data("testdata/v1.0/listing_deep1.cwl"))
-    result = upgrade_document(doc, str(tmp_path), "invalid-version")
+    result = upgrade_document(doc, "invalid-version")
     assert result is None
 
 
-def test_v1_0_to_v1_1(tmp_path: Path) -> None:
+def test_v1_0_to_v1_1() -> None:
     """Basic CWL v1.0 to CWL v1.1 test."""
     doc = load_cwl_document(get_data("testdata/v1.0/listing_deep1.cwl"))
-    upgraded = upgrade_document(doc, str(tmp_path), "v1.1")
+    upgraded = upgrade_document(doc, "v1.1")
     assert doc == upgraded
 
 
-def test_v1_1_to_v1_2(tmp_path: Path) -> None:
+def test_v1_1_to_v1_2() -> None:
     """Basic CWL v1.1 to CWL v1.2 test."""
     doc = load_cwl_document(get_data("testdata/v1.1/listing_deep1.cwl"))
-    upgraded = upgrade_document(doc, str(tmp_path), "v1.2")
+    upgraded = upgrade_document(doc, "v1.2")
     assert doc == upgraded


### PR DESCRIPTION
**Note: it is not ready to merge!**

This request will fixes the [issue mentioned in #78](https://github.com/common-workflow-language/cwl-upgrader/issues/78#issuecomment-966876481).
It contains the following changes:
- Remove `output_dir` and `imports` parameter from `upgrade_document` not to write any files.
  -  It break the functionality of `cwl-upgrader` command. It is the reason why this request also adds `upgrade_all_documents`.
- Add `upgrade_all_documents` that upgrades all CWL documents in `base_dir` recursively and writes upgraded CWL documents to `output_dir` while keeping the directory structure (e.g., `basedir/path/to/tool.cwl` is upgraded and written into `output_dir/path/to/tool.cwl`).


Here is a list to make this request ready to merge:
- [ ] implement upgrading imports
- [ ] Add tests
  - [ ] process docs in nested directories
  - [ ] process imports
- [ ] fix `main` and `run` not to break the functionality of `cwl-upgrader` command