### PR TITLE
Fix tests for upgrade_document

### DIFF
--- a/cwlupgrader/main.py
+++ b/cwlupgrader/main.py
@@ -366,13 +366,13 @@ def _v1_0_to_v1_1(document: CommentedMap, outdir: str) -> CommentedMap:
             move_up_loadcontents(document)
             network_access = has_hint_or_req(document, "NetworkAccess")
             listing = has_hint_or_req(document, "LoadListingRequirement")
-            hints = document.get("hints", {})
+            reqs = document.get("requirements", {})
             # TODO: add comments to explain the extra hints
-            if isinstance(hints, MutableSequence):
+            if isinstance(reqs, MutableSequence):
                 if not network_access:
-                    hints.append({"class": "NetworkAccess", "networkAccess": True})
+                    reqs.append({"class": "NetworkAccess", "networkAccess": True})
                 if not listing:
-                    hints.append(
+                    reqs.append(
                         cmap(
                             {
                                 "class": "LoadListingRequirement",
@@ -380,15 +380,15 @@ def _v1_0_to_v1_1(document: CommentedMap, outdir: str) -> CommentedMap:
                             }
                         )
                     )
-            elif isinstance(hints, MutableMapping):
+            elif isinstance(reqs, MutableMapping):
                 if not network_access:
-                    hints["NetworkAccess"] = {"networkAccess": True}
+                    reqs["NetworkAccess"] = {"networkAccess": True}
                 if not listing:
-                    hints["LoadListingRequirement"] = cmap(
+                    reqs["LoadListingRequirement"] = cmap(
                         {"loadListing": "deep_listing"}
                     )
-            if "hints" not in document:
-                document["hints"] = hints
+            if "requirements" not in document:
+                document["requirements"] = reqs
         elif document["class"] == "ExpressionTool":
             move_up_loadcontents(document)
             cleanup_v1_0_input_bindings(document)

--- a/testdata/v1.0/listing_deep1-arr.cwl
+++ b/testdata/v1.0/listing_deep1-arr.cwl
@@ -1,0 +1,13 @@
+#!/usr/bin/env cwl-runner
+class: CommandLineTool
+cwlVersion: v1.0
+requirements:
+  - class: InlineJavascriptRequirement
+inputs:
+  d: Directory
+outputs:
+  out:
+    type: boolean
+    outputBinding:
+      outputEval: '$(inputs.d.listing.length === 1 && inputs.d.listing[0].listing.length === 1)'
+baseCommand: "true"

--- a/testdata/v1.0/networkaccess.cwl
+++ b/testdata/v1.0/networkaccess.cwl
@@ -1,0 +1,10 @@
+class: CommandLineTool
+cwlVersion: v1.0
+inputs: []
+outputs: []
+baseCommand: python
+arguments:
+  - "-c"
+  - valueFrom: |
+      import urllib.request
+      assert(urllib.request.urlopen("http://commonwl.org").code == 200)

--- a/testdata/v1.1/conflict-wf.cwl
+++ b/testdata/v1.1/conflict-wf.cwl
@@ -6,10 +6,6 @@ $graph:
   hints:
     ResourceRequirement:
       ramMin: 8
-    NetworkAccess:
-      networkAccess: true
-    LoadListingRequirement:
-      loadListing: deep_listing
   inputs:
     text:
       type: string
@@ -24,16 +20,17 @@ $graph:
   baseCommand: echo
   stdout: out.txt
 
+  requirements:
+    NetworkAccess:
+      networkAccess: true
+    LoadListingRequirement:
+      loadListing: deep_listing
 - id: cat
   class: CommandLineTool
   hints:
     ResourceRequirement:
       ramMin: 8
 
-    NetworkAccess:
-      networkAccess: true
-    LoadListingRequirement:
-      loadListing: deep_listing
   inputs:
     file1:
       type: File
@@ -53,6 +50,11 @@ $graph:
   baseCommand: cat
   stdout: out.txt
 
+  requirements:
+    NetworkAccess:
+      networkAccess: true
+    LoadListingRequirement:
+      loadListing: deep_listing
 - class: Workflow
   id: collision
 

--- a/testdata/v1.1/listing_deep1-arr.cwl
+++ b/testdata/v1.1/listing_deep1-arr.cwl
@@ -1,0 +1,17 @@
+#!/usr/bin/env cwl-runner
+class: CommandLineTool
+cwlVersion: v1.1
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: NetworkAccess
+    networkAccess: true
+  - class: LoadListingRequirement
+    loadListing: deep_listing
+inputs:
+  d: Directory
+outputs:
+  out:
+    type: boolean
+    outputBinding:
+      outputEval: '$(inputs.d.listing.length === 1 && inputs.d.listing[0].listing.length === 1)'
+baseCommand: "true"

--- a/testdata/v1.1/listing_deep1.cwl
+++ b/testdata/v1.1/listing_deep1.cwl
@@ -5,6 +5,8 @@ requirements:
   LoadListingRequirement:
     loadListing: deep_listing
   InlineJavascriptRequirement: {}
+  NetworkAccess:
+    networkAccess: true
 inputs:
   d: Directory
 outputs:

--- a/testdata/v1.1/networkaccess.cwl
+++ b/testdata/v1.1/networkaccess.cwl
@@ -1,0 +1,15 @@
+class: CommandLineTool
+cwlVersion: v1.1
+requirements:
+  NetworkAccess:
+    networkAccess: true
+  LoadListingRequirement:
+    loadListing: deep_listing
+inputs: []
+outputs: []
+baseCommand: python
+arguments:
+  - "-c"
+  - valueFrom: |
+      import urllib.request
+      assert(urllib.request.urlopen("http://commonwl.org").code == 200)

--- a/testdata/v1.2/listing_deep1.cwl
+++ b/testdata/v1.2/listing_deep1.cwl
@@ -5,6 +5,8 @@ requirements:
   LoadListingRequirement:
     loadListing: deep_listing
   InlineJavascriptRequirement: {}
+  NetworkAccess:
+    networkAccess: true
 inputs:
   d: Directory
 outputs:

--- a/testdata/v1.2/networkaccess.cwl
+++ b/testdata/v1.2/networkaccess.cwl
@@ -1,0 +1,15 @@
+class: CommandLineTool
+cwlVersion: v1.2
+requirements:
+  NetworkAccess:
+    networkAccess: true
+  LoadListingRequirement:
+    loadListing: deep_listing
+inputs: []
+outputs: []
+baseCommand: python
+arguments:
+  - "-c"
+  - valueFrom: |
+      import urllib.request
+      assert(urllib.request.urlopen("http://commonwl.org").code == 200)

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -41,11 +41,19 @@ def test_invalid_target(tmp_path: Path) -> None:
     assert result is None
 
 
-def test_v1_0_to_v1_1(tmp_path: Path) -> None:
-    """Basic CWL v1.0 to CWL v1.1 test."""
+def test_v1_0_to_v1_1_load_listing(tmp_path: Path) -> None:
+    """Basic CWL v1.0 to CWL v1.1 test with LoadListingRequirement."""
     doc = load_cwl_document(get_data("testdata/v1.0/listing_deep1.cwl"))
     upgraded = upgrade_document(doc, str(tmp_path), "v1.1")
     expected = load_cwl_document(get_data("testdata/v1.1/listing_deep1.cwl"))
+    assert upgraded == expected
+
+
+def test_v1_0_to_v1_1_network_access(tmp_path: Path) -> None:
+    """Basic CWL v1.0 to CWL v1.1 test with NetworkAccess."""
+    doc = load_cwl_document(get_data("testdata/v1.0/networkaccess.cwl"))
+    upgraded = upgrade_document(doc, str(tmp_path), "v1.1")
+    expected = load_cwl_document(get_data("testdata/v1.1/networkaccess.cwl"))
     assert upgraded == expected
 
 
@@ -55,3 +63,13 @@ def test_v1_1_to_v1_2(tmp_path: Path) -> None:
     upgraded = upgrade_document(doc, str(tmp_path), "v1.2")
     expected = load_cwl_document(get_data("testdata/v1.2/listing_deep1.cwl"))
     assert upgraded == expected
+
+
+def test_packed_graph(tmp_path: Path) -> None:
+    """Test packed document with $graph."""
+    main([f"--dir={tmp_path}", "--v1.1-only", get_data("testdata/v1.0/conflict-wf.cwl")])
+    assert filecmp.cmp(
+        get_data("testdata/v1.1/conflict-wf.cwl"),
+        tmp_path / "conflict-wf.cwl",
+        shallow=False,
+    )

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -42,10 +42,18 @@ def test_invalid_target(tmp_path: Path) -> None:
 
 
 def test_v1_0_to_v1_1_load_listing(tmp_path: Path) -> None:
-    """Basic CWL v1.0 to CWL v1.1 test with LoadListingRequirement."""
+    """Basic CWL v1.0 to CWL v1.1 test with LoadListingRequirement (map notation)."""
     doc = load_cwl_document(get_data("testdata/v1.0/listing_deep1.cwl"))
     upgraded = upgrade_document(doc, str(tmp_path), "v1.1")
     expected = load_cwl_document(get_data("testdata/v1.1/listing_deep1.cwl"))
+    assert upgraded == expected
+
+
+def test_v1_0_to_v1_1_load_listing_arr(tmp_path: Path) -> None:
+    """Basic CWL v1.0 to CWL v1.1 test with LoadListingRequirement (array notation)."""
+    doc = load_cwl_document(get_data("testdata/v1.0/listing_deep1-arr.cwl"))
+    upgraded = upgrade_document(doc, str(tmp_path), "v1.1")
+    expected = load_cwl_document(get_data("testdata/v1.1/listing_deep1-arr.cwl"))
     assert upgraded == expected
 
 

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -45,23 +45,13 @@ def test_v1_0_to_v1_1(tmp_path: Path) -> None:
     """Basic CWL v1.0 to CWL v1.1 test."""
     doc = load_cwl_document(get_data("testdata/v1.0/listing_deep1.cwl"))
     upgraded = upgrade_document(doc, str(tmp_path), "v1.1")
-    assert doc == upgraded
+    expected = load_cwl_document(get_data("testdata/v1.1/listing_deep1.cwl"))
+    assert upgraded == expected
 
 
 def test_v1_1_to_v1_2(tmp_path: Path) -> None:
     """Basic CWL v1.1 to CWL v1.2 test."""
     doc = load_cwl_document(get_data("testdata/v1.1/listing_deep1.cwl"))
     upgraded = upgrade_document(doc, str(tmp_path), "v1.2")
-    assert doc == upgraded
-
-
-def test_packed_graph(tmp_path: Path) -> None:
-    """Test packed document with $graph."""
-    main(
-        [f"--dir={tmp_path}", "--v1.1-only", get_data("testdata/v1.0/conflict-wf.cwl")]
-    )
-    assert filecmp.cmp(
-        get_data("testdata/v1.1/conflict-wf.cwl"),
-        tmp_path / "conflict-wf.cwl",
-        shallow=False,
-    )
+    expected = load_cwl_document(get_data("testdata/v1.2/listing_deep1.cwl"))
+    assert upgraded == expected


### PR DESCRIPTION
This request fixes tests that were added by #79 (introduced by me :-( ).
They should check the upgraded document and the expected document but they do not in the current implementation.

I also change `_v1_0_to_v1_1` to add `LoadListingRequirement` and `NetworkAccess` to `requirements` rather than `hints` not to break the behavior of given CWL documents. See  [listing_deep1.cwl](https://github.com/common-workflow-language/cwl-upgrader/blob/main/testdata/v1.0/listing_deep1.cwl) for example.
