### PR TITLE
don't jump to version 2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ DEVPKGS=diff_cover black pylint pep257 pydocstyle flake8 tox tox-pyenv \
 	auto-walrus -rtest-requirements.txt -rmypy-requirements.txt
 DEBDEVPKGS=pylint python3-coverage sloccount \
 	   python3-flake8 shellcheck
-VERSION=2.0.0  # please also update setup.py
+VERSION=1.2.9  # please also update setup.py
 
 ## all                    : default task (install cwl-upgrader in dev mode)
 all: dev

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ PYTEST_RUNNER = ["pytest-runner", "pytest-cov"] if NEEDS_PYTEST else []
 
 setup(
     name="cwl-upgrader",
-    version="2.0.0",
+    version="1.2.9",
     description="Common Workflow Language standalone document upgrader",
     long_description=open(README).read(),
     author="Common Workflow Language contributors",


### PR DESCRIPTION
The MAJOR.MINOR of the `cwl-upgrader` version should match the maximum CWL version supported.